### PR TITLE
Pre render

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import '@/styles/global.css';
 import Navbar from '@/layouts/Navbar.svelte';
 import HighlightToggle from '@/components/highlightIslandToggle.astro';
+import { ClientRouter } from 'astro:transitions';
 
 export interface Props {
   title: string;
@@ -19,6 +20,7 @@ const { title, description = "Astro Demo" } = Astro.props;
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
+    <ClientRouter />
   </head>
   <body class="bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900 min-h-screen flex flex-col text-white debug-islands">
     <Navbar client:load />

--- a/src/pages/cats/[id].astro
+++ b/src/pages/cats/[id].astro
@@ -13,6 +13,8 @@ export async function getStaticPaths() {
 
 const cats = await getCollection('cats');
 const { cat } = Astro.props;
+
+export const prerender = true;
 ---
 
 <Layout title={`Gato ${cat.id} - CatWorld`}>

--- a/src/pages/cats/gallery.astro
+++ b/src/pages/cats/gallery.astro
@@ -4,6 +4,8 @@ import { getCollection } from 'astro:content';
 import CatGrid from '@/components/cats/CatGrid.astro';
 
 const cats = await getCollection('cats');
+
+export const prerender = true;
 ---
 
 <Layout title="Galería SSG - CatWorld" description={`Galería estática generada con ${cats.length} gatos usando Astro Content Collections`}>

--- a/src/pages/cats/index.astro
+++ b/src/pages/cats/index.astro
@@ -6,6 +6,8 @@ import FeaturedCats from '@/components/cats/FeaturedCats.astro';
 
 const cats = await getCollection('cats');
 const featuredCats = cats.slice(0, 6);
+
+export const prerender = true;
 ---
 
 <Layout title="CatWorld - Demostración de Astro SSG + Content Collections">

--- a/src/pages/movies/[slug].astro
+++ b/src/pages/movies/[slug].astro
@@ -19,6 +19,8 @@ const data = movie.data;
 const relatedMovies = allMovies
   .filter((m) => m.data.slug !== data.slug && m.data.major_genre === data.major_genre)
   .slice(0, 6);
+
+export const prerender = true;
 ---
 
 <Layout title={`Pelicula ${data.title} - MoviesWorld`}>

--- a/src/pages/movies/gallery.astro
+++ b/src/pages/movies/gallery.astro
@@ -4,6 +4,8 @@ import { getCollection } from 'astro:content';
 import MoviesGrid from '@/components/movies/MovieGrid.astro';
 
 const movies = await getCollection('movies');
+
+export const prerender = true;
 ---
 
 <Layout title="Galería de Películas - MoviesWorld" description="Explora nuestra colección de películas destacadas">

--- a/src/pages/movies/index.astro
+++ b/src/pages/movies/index.astro
@@ -5,6 +5,8 @@ import FeaturedMovies from '@/components/movies/FeaturedMovies.astro';
 
 const movies = await getCollection('movies');
 const featuredMovies = movies.slice(0, 6);
+
+export const prerender = true;
 ---
 
 <Layout title="MoviesWorld - Demostración de Astro SSG + Content Collections">


### PR DESCRIPTION
This pull request introduces two main sets of changes: enabling static site generation (SSG) for various pages and adding client-side routing capabilities. The changes improve performance by pre-rendering pages and enhance user experience with smoother transitions.

### Static Site Generation (SSG) Enhancements:
* Added `export const prerender = true;` to enable SSG for the following pages:
  - `src/pages/cats/[id].astro` ([src/pages/cats/[id].astroR16-R17](diffhunk://#diff-51cb338acda8fbcd1f1a7727f7709e10042e15c38123d8f246df804b8d1c42b0R16-R17))
  - `src/pages/cats/gallery.astro`
  - `src/pages/cats/index.astro`
  - `src/pages/movies/[slug].astro` ([src/pages/movies/[slug].astroR22-R23](diffhunk://#diff-2a4e34377d94d2160403ba9f16bc76538f2a1f4d6eda81d10cece385bc1c6e47R22-R23))
  - `src/pages/movies/gallery.astro`
  - `src/pages/movies/index.astro`

### Client-Side Routing Addition:
* Imported `ClientRouter` from `astro:transitions` in `src/layouts/Layout.astro` and added `<ClientRouter />` to the `<head>` section to enable client-side routing for smoother page transitions. [[1]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2R5) [[2]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2R23)